### PR TITLE
Add a `formatToParts`

### DIFF
--- a/__tests__/extended-format.test.js
+++ b/__tests__/extended-format.test.js
@@ -1,7 +1,7 @@
-import { text } from './helpers';
+import { text, partsFormatter } from './helpers';
 
 describe('Extended format', () => {
-  it('formats duration in English with long format', () => {
+  it('formats duration in English with long format (react)', () => {
     expect(text(1)).toEqual('1 second');
     expect(text(30)).toEqual('30 seconds');
     expect(text(59)).toEqual('59 seconds');
@@ -11,5 +11,71 @@ describe('Extended format', () => {
     expect(text(120)).toEqual('2 minutes');
     expect(text(121)).toEqual('2 minutes 1 second');
     expect(text(150)).toEqual('2 minutes 30 seconds');
+  });
+
+  it('formats duration in English with long format (parts)', () => {
+    const parts = partsFormatter();
+
+    expect(parts(1)).toEqual([
+      { type: 'second', value: '1' },
+      { type: 'literal', value: ' ' },
+      { type: 'unit', value: 'second' },
+    ]);
+    expect(parts(30)).toEqual([
+      { type: 'second', value: '30' },
+      { type: 'literal', value: ' ' },
+      { type: 'unit', value: 'seconds' },
+    ]);
+    expect(parts(59)).toEqual([
+      { type: 'second', value: '59' },
+      { type: 'literal', value: ' ' },
+      { type: 'unit', value: 'seconds' },
+    ]);
+    expect(parts(60)).toEqual([
+      { type: 'minute', value: '1' },
+      { type: 'literal', value: ' ' },
+      { type: 'unit', value: 'minute' },
+    ]);
+    expect(parts(61)).toEqual([
+      { type: 'minute', value: '1' },
+      { type: 'literal', value: ' ' },
+      { type: 'unit', value: 'minute' },
+      { type: 'literal', value: ' ' },
+      { type: 'second', value: '1' },
+      { type: 'literal', value: ' ' },
+      { type: 'unit', value: 'second' },
+    ]);
+    expect(parts(62)).toEqual([
+      { type: 'minute', value: '1' },
+      { type: 'literal', value: ' ' },
+      { type: 'unit', value: 'minute' },
+      { type: 'literal', value: ' ' },
+      { type: 'second', value: '2' },
+      { type: 'literal', value: ' ' },
+      { type: 'unit', value: 'seconds' },
+    ]);
+    expect(parts(120)).toEqual([
+      { type: 'minute', value: '2' },
+      { type: 'literal', value: ' ' },
+      { type: 'unit', value: 'minutes' },
+    ]);
+    expect(parts(121)).toEqual([
+      { type: 'minute', value: '2' },
+      { type: 'literal', value: ' ' },
+      { type: 'unit', value: 'minutes' },
+      { type: 'literal', value: ' ' },
+      { type: 'second', value: '1' },
+      { type: 'literal', value: ' ' },
+      { type: 'unit', value: 'second' },
+    ]);
+    expect(parts(150)).toEqual([
+      { type: 'minute', value: '2' },
+      { type: 'literal', value: ' ' },
+      { type: 'unit', value: 'minutes' },
+      { type: 'literal', value: ' ' },
+      { type: 'second', value: '30' },
+      { type: 'literal', value: ' ' },
+      { type: 'unit', value: 'seconds' },
+    ]);
   });
 });

--- a/__tests__/helpers/index.js
+++ b/__tests__/helpers/index.js
@@ -1,7 +1,10 @@
 import React from 'react';
 import { mountWithIntl } from 'enzyme-react-intl';
+import { IntlProvider } from 'react-intl';
 
-import DurationMessage from '../../index';
+import DurationMessage, {
+  formatToParts,
+} from '../../index';
 
 function Text(props) {
   return <span {...props}/>;
@@ -9,4 +12,10 @@ function Text(props) {
 
 export function text(value, format) {
   return mountWithIntl(<DurationMessage seconds={value} format={format} textComponent={Text} />).text().trim().replace(/\s+/g, ' ');
+}
+
+export function partsFormatter(format, locale = 'en', messages = {}) {
+  const intlProvider = new IntlProvider({ locale, messages }, {});
+  const intl = intlProvider.getChildContext().intl;
+  return (seconds) => formatToParts(intl, format, seconds);
 }

--- a/__tests__/optional-format.test.js
+++ b/__tests__/optional-format.test.js
@@ -1,7 +1,7 @@
-import { text } from './helpers';
+import { text, partsFormatter } from './helpers';
 
 describe('Optional format', () => {
-  it('formats duration using hours', () => {
+  it('formats duration using hours (react)', () => {
     const format = '{hours} {minutes} {seconds}';
     expect(text(1, format)).toEqual('1 second');
     expect(text(60, format)).toEqual('1 minute');
@@ -15,7 +15,7 @@ describe('Optional format', () => {
     expect(text(90000, format)).toEqual('25 hours');
   });
 
-  it('formats duration using days and ignoring seconds', () => {
+  it('formats duration using days and ignoring seconds (react)', () => {
     const format = '{days} {hours} {minutes}';
     expect(text(1, format)).toEqual('0 minutes');
     expect(text(60, format)).toEqual('1 minute');
@@ -29,5 +29,175 @@ describe('Optional format', () => {
     expect(text(86400, format)).toEqual('1 day');
     expect(text(90000, format)).toEqual('1 day 1 hour');
     expect(text(180000, format)).toEqual('2 days 2 hours');
+  });
+
+  it('formats duration using hours (parts)', () => {
+    const parts = partsFormatter('{hours} {minutes} {seconds}');
+    expect(parts(1)).toEqual([
+      { type: 'second', value: '1' },
+      { type: 'literal', value: ' ' },
+      { type: 'unit', value: 'second' },
+    ]);
+    expect(parts(60)).toEqual([
+      { type: 'minute', value: '1' },
+      { type: 'literal', value: ' ' },
+      { type: 'unit', value: 'minute' },
+    ]);
+    expect(parts(61)).toEqual([
+      { type: 'minute', value: '1' },
+      { type: 'literal', value: ' ' },
+      { type: 'unit', value: 'minute' },
+      { type: 'literal', value: ' ' },
+      { type: 'second', value: '1' },
+      { type: 'literal', value: ' ' },
+      { type: 'unit', value: 'second' },
+    ]);
+    expect(parts(3600)).toEqual([
+      { type: 'hour', value: '1' },
+      { type: 'literal', value: ' ' },
+      { type: 'unit', value: 'hour' },
+    ]);
+    expect(parts(3601)).toEqual([
+      { type: 'hour', value: '1' },
+      { type: 'literal', value: ' ' },
+      { type: 'unit', value: 'hour' },
+      { type: 'literal', value: ' ' },
+      { type: 'second', value: '1' },
+      { type: 'literal', value: ' ' },
+      { type: 'unit', value: 'second' },
+    ]);
+    expect(parts(3602)).toEqual([
+      { type: 'hour', value: '1' },
+      { type: 'literal', value: ' ' },
+      { type: 'unit', value: 'hour' },
+      { type: 'literal', value: ' ' },
+      { type: 'second', value: '2' },
+      { type: 'literal', value: ' ' },
+      { type: 'unit', value: 'seconds' },
+    ]);
+    expect(parts(3660)).toEqual([
+      { type: 'hour', value: '1' },
+      { type: 'literal', value: ' ' },
+      { type: 'unit', value: 'hour' },
+      { type: 'literal', value: ' ' },
+      { type: 'minute', value: '1' },
+      { type: 'literal', value: ' ' },
+      { type: 'unit', value: 'minute' },
+    ]);
+    expect(parts(3661)).toEqual([
+      { type: 'hour', value: '1' },
+      { type: 'literal', value: ' ' },
+      { type: 'unit', value: 'hour' },
+      { type: 'literal', value: ' ' },
+      { type: 'minute', value: '1' },
+      { type: 'literal', value: ' ' },
+      { type: 'unit', value: 'minute' },
+      { type: 'literal', value: ' ' },
+      { type: 'second', value: '1' },
+      { type: 'literal', value: ' ' },
+      { type: 'unit', value: 'second' },
+    ]);
+    expect(parts(7322)).toEqual([
+      { type: 'hour', value: '2' },
+      { type: 'literal', value: ' ' },
+      { type: 'unit', value: 'hours' },
+      { type: 'literal', value: ' ' },
+      { type: 'minute', value: '2' },
+      { type: 'literal', value: ' ' },
+      { type: 'unit', value: 'minutes' },
+      { type: 'literal', value: ' ' },
+      { type: 'second', value: '2' },
+      { type: 'literal', value: ' ' },
+      { type: 'unit', value: 'seconds' },
+    ]);
+    expect(parts(90000)).toEqual([
+      { type: 'hour', value: '25' },
+      { type: 'literal', value: ' ' },
+      { type: 'unit', value: 'hours' },
+    ]);
+  });
+
+  it('formats duration using days and ignoring seconds (parts)', () => {
+    const parts = partsFormatter('{days} {hours} {minutes}');
+    expect(parts(1)).toEqual([
+      { type: 'minute', value: '0' },
+      { type: 'literal', value: ' ' },
+      { type: 'unit', value: 'minutes' },
+    ]);
+    expect(parts(60)).toEqual([
+      { type: 'minute', value: '1' },
+      { type: 'literal', value: ' ' },
+      { type: 'unit', value: 'minute' },
+    ]);
+    expect(parts(61)).toEqual([
+      { type: 'minute', value: '1' },
+      { type: 'literal', value: ' ' },
+      { type: 'unit', value: 'minute' },
+    ]);
+    expect(parts(110)).toEqual([
+      { type: 'minute', value: '2' },
+      { type: 'literal', value: ' ' },
+      { type: 'unit', value: 'minutes' },
+    ]);
+    expect(parts(3600)).toEqual([
+      { type: 'hour', value: '1' },
+      { type: 'literal', value: ' ' },
+      { type: 'unit', value: 'hour' },
+    ]);
+    expect(parts(3601)).toEqual([
+      { type: 'hour', value: '1' },
+      { type: 'literal', value: ' ' },
+      { type: 'unit', value: 'hour' },
+    ]);
+    expect(parts(3660)).toEqual([
+      { type: 'hour', value: '1' },
+      { type: 'literal', value: ' ' },
+      { type: 'unit', value: 'hour' },
+      { type: 'literal', value: ' ' },
+      { type: 'minute', value: '1' },
+      { type: 'literal', value: ' ' },
+      { type: 'unit', value: 'minute' },
+    ]);
+    expect(parts(3661)).toEqual([
+      { type: 'hour', value: '1' },
+      { type: 'literal', value: ' ' },
+      { type: 'unit', value: 'hour' },
+      { type: 'literal', value: ' ' },
+      { type: 'minute', value: '1' },
+      { type: 'literal', value: ' ' },
+      { type: 'unit', value: 'minute' },
+    ]);
+    expect(parts(7322)).toEqual([
+      { type: 'hour', value: '2' },
+      { type: 'literal', value: ' ' },
+      { type: 'unit', value: 'hours' },
+      { type: 'literal', value: ' ' },
+      { type: 'minute', value: '2' },
+      { type: 'literal', value: ' ' },
+      { type: 'unit', value: 'minutes' },
+    ]);
+    expect(parts(86400)).toEqual([
+      { type: 'day', value: '1' },
+      { type: 'literal', value: ' ' },
+      { type: 'unit', value: 'day' },
+    ]);
+    expect(parts(90000)).toEqual([
+      { type: 'day', value: '1' },
+      { type: 'literal', value: ' ' },
+      { type: 'unit', value: 'day' },
+      { type: 'literal', value: ' ' },
+      { type: 'hour', value: '1' },
+      { type: 'literal', value: ' ' },
+      { type: 'unit', value: 'hour' },
+    ]);
+    expect(parts(180000)).toEqual([
+      { type: 'day', value: '2' },
+      { type: 'literal', value: ' ' },
+      { type: 'unit', value: 'days' },
+      { type: 'literal', value: ' ' },
+      { type: 'hour', value: '2' },
+      { type: 'literal', value: ' ' },
+      { type: 'unit', value: 'hours' },
+    ]);
   });
 });

--- a/__tests__/timer-format.test.js
+++ b/__tests__/timer-format.test.js
@@ -1,9 +1,9 @@
-import { text } from './helpers';
+import { text, partsFormatter } from './helpers';
 
 import { TIMER_FORMAT } from '../index';
 
 describe('Timer format', () => {
-  it('formats duration in English with timer formar', () => {
+  it('formats duration in English with timer format (react)', () => {
     expect(text(1, TIMER_FORMAT)).toEqual('0:01');
     expect(text(30, TIMER_FORMAT)).toEqual('0:30');
     expect(text(59, TIMER_FORMAT)).toEqual('0:59');
@@ -13,5 +13,55 @@ describe('Timer format', () => {
     expect(text(120, TIMER_FORMAT)).toEqual('2:00');
     expect(text(121, TIMER_FORMAT)).toEqual('2:01');
     expect(text(150, TIMER_FORMAT)).toEqual('2:30');
+  });
+
+  it('formats duration in English with timer format (parts)', () => {
+    const parts = partsFormatter(TIMER_FORMAT);
+
+    expect(parts(1)).toEqual([
+      { type: 'minute', value: '0' },
+      { type: 'literal', value: ':' },
+      { type: 'second', value: '01' },
+    ]);
+    expect(parts(30)).toEqual([
+      { type: 'minute', value: '0' },
+      { type: 'literal', value: ':' },
+      { type: 'second', value: '30' },
+    ]);
+    expect(parts(59)).toEqual([
+      { type: 'minute', value: '0' },
+      { type: 'literal', value: ':' },
+      { type: 'second', value: '59' },
+    ]);
+    expect(parts(60)).toEqual([
+      { type: 'minute', value: '1' },
+      { type: 'literal', value: ':' },
+      { type: 'second', value: '00' },
+    ]);
+    expect(parts(61)).toEqual([
+      { type: 'minute', value: '1' },
+      { type: 'literal', value: ':' },
+      { type: 'second', value: '01' },
+    ]);
+    expect(parts(62)).toEqual([
+      { type: 'minute', value: '1' },
+      { type: 'literal', value: ':' },
+      { type: 'second', value: '02' },
+    ]);
+    expect(parts(120)).toEqual([
+      { type: 'minute', value: '2' },
+      { type: 'literal', value: ':' },
+      { type: 'second', value: '00' },
+    ]);
+    expect(parts(121)).toEqual([
+      { type: 'minute', value: '2' },
+      { type: 'literal', value: ':' },
+      { type: 'second', value: '01' },
+    ]);
+    expect(parts(150)).toEqual([
+      { type: 'minute', value: '2' },
+      { type: 'literal', value: ':' },
+      { type: 'second', value: '30' },
+    ]);
   });
 });

--- a/index.js
+++ b/index.js
@@ -17,9 +17,10 @@ import PropTypes from 'prop-types';
 import { FormattedMessage, injectIntl, intlShape } from 'react-intl';
 
 import messages from './messages';
-
-export const EXTENDED_FORMAT = 'EXTENDED_FORMAT';
-export const TIMER_FORMAT = 'TIMER_FORMAT';
+import {
+  EXTENDED_FORMAT,
+  TIMER_FORMAT
+} from './src/constants';
 
 function FormattedUnit({ value, showIfZero, message, textComponent, valueComponent }) {
   if (!value && !showIfZero) {
@@ -161,3 +162,9 @@ DurationMessage.propTypes = {
 };
 
 export default injectIntl(DurationMessage);
+export { formatToParts } from './src/parts';
+
+export {
+  EXTENDED_FORMAT,
+  TIMER_FORMAT
+};

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,2 @@
+export const EXTENDED_FORMAT = 'EXTENDED_FORMAT';
+export const TIMER_FORMAT = 'TIMER_FORMAT';

--- a/src/parts.js
+++ b/src/parts.js
@@ -1,0 +1,142 @@
+import messages from '../messages';
+import {
+  EXTENDED_FORMAT,
+  TIMER_FORMAT,
+} from './constants';
+
+export function formatToParts(intl, format, seconds) {
+  const message = getMessage(format);
+  const formatter = format === TIMER_FORMAT ? formatPadding : formatWithDuration;
+
+  // Basic match that doesn't depend on the format message
+  const fullDays = Math.floor(seconds / 86400);
+  const fullHours = Math.floor(seconds / 3600);
+  const hoursLeft = Math.floor(fullHours % 24);
+  const fullMinutes = Math.floor(seconds / 60);
+  const minutesLeft = Math.floor(fullMinutes % 60);
+  const secondsLeft = seconds % 60;
+
+  const valueGetters = {
+    days: (has) => has.days ? {
+      type: 'day',
+      value: fullDays,
+      maxLengthIfPadded: 1,
+      showIfZero: false,
+      message: messages.daysUnit,
+    } : undefined,
+    hours: (has) => {
+      const showFullHours = !has.days;
+      return has.hours ? {
+        type: 'hour',
+        value: showFullHours ? fullHours : hoursLeft,
+        maxLengthIfPadded: 1,
+        showIfZero: false,
+        message: messages.hoursUnit,
+      } : undefined;
+    },
+    minutes: (has) => {
+      const showFullMinutes = !has.hours && !has.days;
+      return {
+        type: 'minute',
+        value: (showFullMinutes ? fullMinutes : minutesLeft) + ((!has.seconds && secondsLeft >= 30) ? 1 : 0),
+        maxLengthIfPadded: 1,
+        showIfZero: !has.seconds && fullHours === 0,
+        message: messages.minutesUnit,
+      }
+    },
+    seconds: (has) => has.seconds ? {
+      type: 'second',
+      value: secondsLeft,
+      maxLengthIfPadded: 2,
+      showIfZero: false,
+      message: messages.secondsUnit,
+    } : undefined,
+  }
+
+  return trim(splitIntoTokens(intl, message, valueGetters, formatter));
+}
+
+// Creates a token with a random UID that should not be guessable or
+// conflict with other parts of the `message` string.
+const UID = Math.floor(Math.random() * 0x10000000000).toString(16);
+
+function splitIntoTokens(intl, message, valueGetters, formatter) {
+  // We only recognise some tokens in the localised message, remember which one
+  // we actually encounter in the localised message
+  const has = {};
+  const original = {};
+  const formattingValues = Object.keys(valueGetters).reduce((all, name) => {
+    Object.defineProperty(all, name, {
+      get() {
+        // There are some edge cases in simply relying on `indexOf('{seconds}')` of the default message
+        // Use getters to know for sure that the value is actually used in the localised message
+        has[name] = true;
+        const generatedName = `@__TOKEN-${UID}-${name}__@`;
+        original[generatedName] = name;
+        return generatedName;
+      }
+    });
+    return all;
+  }, {});
+
+  const formattedMessage = intl.formatMessage(message, formattingValues);
+
+  const tokens = [];
+  formattedMessage.split(new RegExp(`(@__TOKEN-${UID}-.+?__@)`)).forEach((chunk) => {
+    if (!chunk) return;
+    if (!original[chunk]) {
+      // literal value, ignore white space at the beginning or repeated
+      if (tokens.length === 0 || isEmpty(tokens[tokens.length - 1])) return;
+      tokens.push({ type: 'literal', value: chunk });
+    } else {
+      tokens.push(...formatter(valueGetters[original[chunk]](has), intl).filter(Boolean));
+    }
+  });
+  return tokens;
+}
+
+function getMessage(format) {
+  switch (format) {
+    case TIMER_FORMAT:
+      return messages.timerFormatting;
+    case EXTENDED_FORMAT:
+      return messages.longFormatting;
+    default:
+      return format ? {
+        id: `react-intl-formatted-duration/custom-format/${format}`,
+        defaultMessage: format,
+      } : messages.longFormatting;
+  }
+}
+
+function formatPadding({ type, value, maxLengthIfPadded }) {
+  return [{ type, value: `0${value || '0'}`.substr(-maxLengthIfPadded) }];
+}
+
+function formatWithDuration({ type, message, value, showIfZero }, intl) {
+  if (!value && !showIfZero) {
+    return [];
+  }
+
+  const valueGetters = {
+    value: () => [{ type, value: String(value) }],
+    unit: () => [{
+      type: 'unit',
+      value: intl.formatMessage(message, { value }),
+    }],
+  };
+
+  return splitIntoTokens(intl, messages.duration, valueGetters, (token) => token);
+}
+
+function trim(tokens) {
+  // We don't push empty literals at the beginning or repeated, but there might be one at the end
+  if (isEmpty(tokens[tokens.length - 1])) {
+    tokens.pop();
+  }
+  return tokens;
+}
+
+function isEmpty(part) {
+  return part.type === 'literal' && !part.value.trim();
+}


### PR DESCRIPTION
@pictawall I started having a look at your PR and wanted to see if there's a way to split it so I can better understand the changes.

I ended up rewriting the whole `formatDurationToParts` because I wasn't too happy about the implementation of `formatMessageToParts` (which I believe you mostly took from intl-messageformat).
Also I didn't like having `while` loops 😁 

Changes from you PR

* `formatDurationToParts` renamed to -> `formatToParts` because it's a similar function as `DateTimeFormat#formatToParts` what do you think?
* the function now generate tokens `second`, `minute` ... even if the localised message uses `seconds` and `minutes`. I think it's better to stay as close as possible to the native method. Not sure if we have to break compatibility with the old messages, let's see how this goes

I updated all tests for all formats except the ones in japanese, I'm done for today.

Do you mind having a look and see how it works?

Once we have a base function for generating parts the rest should be easier right?