### PR TITLE
Move intl-unofficial-duration-unit-format out of dev deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4367,8 +4367,7 @@
     "intl-unofficial-duration-unit-format": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/intl-unofficial-duration-unit-format/-/intl-unofficial-duration-unit-format-1.0.0.tgz",
-      "integrity": "sha512-PiJnXxpX7QFjLq9q+jORHJnWhCvmon9cxQOR4NUIQt1AXLfCqCeZ/lkvt1aMV4qIFC7E9rP8jJj5Iz8RULi7sg==",
-      "dev": true
+      "integrity": "sha512-PiJnXxpX7QFjLq9q+jORHJnWhCvmon9cxQOR4NUIQt1AXLfCqCeZ/lkvt1aMV4qIFC7E9rP8jJj5Iz8RULi7sg=="
     },
     "invariant": {
       "version": "2.2.4",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "eslint-plugin-flowtype": "^3.1.4",
     "eslint-plugin-react": "^7.11.1",
     "flow-bin": "^0.85.0",
-    "intl-unofficial-duration-unit-format": "1.0.0",
     "jest": "^23.6.0",
     "prop-types": "^15.6.2",
     "react": "^16.6.0",
@@ -75,5 +74,8 @@
     "transform": {
       ".*": "<rootDir>/node_modules/babel-jest"
     }
+  },
+  "dependencies": {
+    "intl-unofficial-duration-unit-format": "1.0.0"
   }
 }


### PR DESCRIPTION
Even though the NPM package doesn't break, when I run `flow check` in my project, it complains that `intl-unofficial-duration-unit-format` cannot be found.